### PR TITLE
Layout support

### DIFF
--- a/mustache-express.js
+++ b/mustache-express.js
@@ -147,7 +147,7 @@ function create(directory, extension) {
 		render(templatePath, viewDirectory, viewExtension, options, rendererWrapper.cache, function(err, data) {
 			
 			// If layout is defined, load it
-			if(options && options.settings && ptions.settings.layout) {
+			if(options && options.settings && options.settings.layout) {
 				
 				// Load the layout & partials
 				var layoutPath = path.resolve(viewDirectory, options.settings.layout + viewExtension);


### PR DESCRIPTION
Support for the layout option is missing.

For example:

app.set('layout', 'layouts/user');
So that the layout is always rendered with the rendered view injected into it (into {{{ yield }}} tag).
