### PR TITLE
Add a license to the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
       "email": "mikko.tikkanen@gmail.com>"
     }
   ],
+  "license": "MIT",
   "dependencies": {
     "async": "~0.2.10",
     "lru-cache": "~2.5.0",


### PR DESCRIPTION
A LICENSE.md file already existed, but the license should also be in the
package.json.