### PR TITLE
added support for a partial in a negative conditional

### DIFF
--- a/find-partials.js
+++ b/find-partials.js
@@ -13,7 +13,7 @@ function iteratePartials(parsed) {
 	});
 
 	parsed.filter(function (i) {
-		return i[0] === "#";
+		return i[0] === "#" || i[0] === '^';
 	}).map(function(i) {
 		iteratePartials(i[4]).map(function(i) {
 			partialSet[i] = true;

--- a/test/find-partials.js
+++ b/test/find-partials.js
@@ -25,8 +25,14 @@ describe('findPartials', function() {
 		sort(results).should.eql(["p1"]);
 	});
 
+	it('should find partials inside a negative conditional', function() {
+		var results = findPartials("{{^test}}{{> p1}}{{/test}}");
+		sort(results).should.eql(["p1"]);
+	});
+
 	it('should only return a partial once', function() {
 		var results = findPartials("{{> p1}} {{> p1}}");
 		sort(results).should.eql(["p1"]);
 	});
+
 });


### PR DESCRIPTION
the findPartials function was failing for this condition:

```
{{^available}}
  {{> notFound }}
{{/available}}
```

I introduced the fix and the tests accordingly