### PR TITLE
chore(package): bump mustache to ~2.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "async": "~0.2.10",
     "lru-cache": "~2.5.0",
-    "mustache": "~2.2.0"
+    "mustache": "~2.3.0"
   },
   "devDependencies": {
     "grunt": "~0.4",


### PR DESCRIPTION
Mustache 2.3.0 was released yesterday, updating our dependencies pulling their last version.

Not updating package's version number, as our last PR didn't reach npmjs's registry yet.
(Continuing bryanburgers/node-mustache-express#18, pending release)