### PR TITLE
Send options to layout

### DIFF
--- a/mustache-express.js
+++ b/mustache-express.js
@@ -7,6 +7,12 @@ var lruCache = require('lru-cache');
 var mustache = require('mustache');
 var path = require('path');
 
+// Make sure Object.assign exists
+var extend = Object.assign;
+if (!extend) {
+	extend = require("util")._extend;
+}
+
 // Load a single file, and return the data.
 function loadFile(fullFilePath, callback) {
 	fs.readFile(fullFilePath, "utf-8", function(err, data) {

--- a/mustache-express.js
+++ b/mustache-express.js
@@ -7,7 +7,7 @@ var lruCache = require('lru-cache');
 var mustache = require('mustache');
 var path = require('path');
 
-// Make sure Object.assign exists
+// Make sure Object.assign exists. If not, default to Node's internal extend.
 var extend = Object.assign;
 if (!extend) {
 	extend = require("util")._extend;
@@ -166,7 +166,7 @@ function create(directory, extension) {
 					}
 
 					// Render the view into layout and run the callback
-					var fulldata = mustache.render(template, Object.assign({yield: data}, options), partials);
+					var fulldata = mustache.render(template, extend({yield: data}, options), partials);
 					callback(err, fulldata);
 				});
 

--- a/mustache-express.js
+++ b/mustache-express.js
@@ -160,7 +160,7 @@ function create(directory, extension) {
 					}
 
 					// Render the view into layout and run the callback
-					var fulldata = mustache.render(template, {yield: data}, partials);
+					var fulldata = mustache.render(template, Object.assign({yield: data}, options), partials);
 					callback(err, fulldata);
 				});
 


### PR DESCRIPTION
When rendering the layout, send the same options as were sent to the
template. This allows for common scenarios like having the template text
change depending on who is logged in.