### PR TITLE
Handling uncaught error during template parsing

### DIFF
--- a/mustache-express.js
+++ b/mustache-express.js
@@ -36,7 +36,13 @@ function handleFile(name, file, options, cache, callback) {
 				return callback(err);
 			}
 
-			var partials = findPartials(fileData);
+			var partials;
+			try {
+				partials = findPartials(fileData);
+			} catch (err) {
+				return callback(err);
+			}
+
 			var data = {
 				name: name,
 				data: fileData,


### PR DESCRIPTION
Hello there,

When a template is not valid (unclosed `{{#tag}}` for example), an error is thrown, crashing the whole app.
It feels like it should be handled that way:

```js
try {
  res.render(path, locals)
} catch (err) {
  next(err);
}
```
or, with a callback:
```js
res.render(path, locals, (err, text) => {
   if (err) return next(err);
   res.send(text);
});
```

Let me know.

Cheers,