### PR TITLE
Allow `partialsDirectory` to be a function

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Mustache Express lets you use Mustache and Express (at least version 3) together
 
 The mustacheExpress method can take two parameters: the directory of the partials and the extension of the partials. When a partial is requested by a template, the file will be loaded from `path.resolve(directory, partialName + extension)`. By default, these values are determined by Express.
 
+If a function is passed to `views` parameter a user space view lookup can be performed.
+
+EG: `app.set('views',(partial,ext)=>{return path.resolve(someDir,partial + ext)})`
+
 ## Properties
 
 The return function has a `cache` parameter that is an [LRU Cache](https://github.com/isaacs/node-lru-cache).

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ Mustache Express lets you use Mustache and Express (at least version 3) together
 
 The mustacheExpress method can take two parameters: the directory of the partials and the extension of the partials. When a partial is requested by a template, the file will be loaded from `path.resolve(directory, partialName + extension)`. By default, these values are determined by Express.
 
-If a function is passed to `views` parameter a user space view lookup can be performed.
+If a function is passed to `viewHelper` parameter a user space view lookup can be performed.
 
-EG: `app.set('views',(partial,ext)=>{return path.resolve(someDir,partial + ext)})`
+EG: `app.set('viewHelper',(partial,ext)=>{return path.resolve(someDir,partial + ext)})`
 
 ## Properties
 

--- a/mustache-express.js
+++ b/mustache-express.js
@@ -160,6 +160,9 @@ function create(directory, extension) {
 	});
 	var rendererWrapper = function(templatePath, options, callback) {
 		var viewDirectory = directory || options.settings.views;
+		if(options.settings && 'function' === typeof options.settings.viewHelper){
+			viewDirectory = options.settings.viewHelper;
+		}
 		var viewExtension = extension || '.' + options.settings['view engine'];
 		render(templatePath, viewDirectory, viewExtension, options, rendererWrapper.cache, function(err, data) {
 			if (err) {

--- a/mustache-express.js
+++ b/mustache-express.js
@@ -92,7 +92,12 @@ function loadAllPartials(unparsedPartials, partialsDirectory, partialsExtension,
 	}
 
 	async.map(unparsedPartials, function(partial, next) {
-		var fullFilePath = path.resolve(partialsDirectory, partial + partialsExtension);
+		var fullFilePath;
+		if('function' === typeof partialsDirectory){
+			fullFilePath = partialsDirectory(partial,partialsExtension);
+		} else {
+			fullFilePath = path.resolve(partialsDirectory, partial + partialsExtension);
+		}
 		return handleFile(partial, fullFilePath, options, cache, next);
 	}, function(err, data) {
 		if (err) {


### PR DESCRIPTION
This PR will support the `partialsDirectory` parameter which is read from `app.settings.views` being a function. Once a function is provided user space can perform the procedures of looking up the view. This will support more complex scenarios with a very tiny patch to the library.

I included documentation in this PR in a separate commit in case it needs to be dropped or revised.

My example use case is as follows
```js
    app.locals.basedir = path.resolve(interfaceRoot + '/view')
    app.set('views',(partial,extension) => {
      //see if we have a registered view
      let fp = app.view.get(partial)
      //otherwise use the system path
      if(!fp) fp = path.join(app.locals.basedir,partial + extension)
      return fp
    })
```

Please consider this upgrade for the next release. My usage is going to appear in https://github.com/KadoOrg/kado 

Thank you!