### PR TITLE
Update Node.js versions for Travis CI + packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: node_js
 node_js:
-  - "4"
+  - "16"
+  - "14"
+  - "12"

--- a/package.json
+++ b/package.json
@@ -52,15 +52,15 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "async": "~3.1.0",
+    "async": "~3.2.0",
     "lru-cache": "~5.1.1",
-    "mustache": "^3.1.0"
+    "mustache": "^3.2.1"
   },
   "devDependencies": {
-    "grunt": "~1.0.4",
+    "grunt": "~1.4.0",
     "grunt-contrib-jshint": "~2.1.0",
-    "jshint": "~2.10.2",
-    "mocha": "~6.2.0",
+    "jshint": "~2.12.0",
+    "mocha": "~8.4.0",
     "should": "~13.2.3"
   },
   "engines": {


### PR DESCRIPTION
Node.js versions below 10.x are not maintained anymore, so it is probably best to use some newer, still maintained versions when testing on Travis CI. For release cycles of Node.js see the official site: <https://nodejs.org/en/about/releases/>.

Furthermore, dependencies have been updated.