### PR TITLE
Tell the user what file errors occur in

### DIFF
--- a/mustache-express.js
+++ b/mustache-express.js
@@ -33,14 +33,14 @@ function handleFile(name, file, options, cache, tags, callback) {
 	if (!cachedData) {
 		loadFile(file, function(err, fileData) {
 			if (err) {
-				return callback(err);
+				return callback("An error occurred while reading " + file + ":\n" + err);
 			}
 
 			var partials;
 			try {
 				partials = findPartials(fileData, tags);
 			} catch (err) {
-				return callback(err);
+				return callback("An error occurred while rendering " + file + ":\n" + err);
 			}
 
 			var data = {


### PR DESCRIPTION
When an error occurs, the error often doesn't give any information needed to fix the problem. For example this one:
```
Error: Unclosed tag at 4568
```
I know there's an unclosed tag somewhere, but I have no way of knowing where. With this small change, the quality of the error messages improve by 1000%:
```
An error occurred while rendering C:\Users\...\src\partials\footer.html:
Error: Unclosed tag at 4568
```
Now I can look in my `footer` partial and actually fix the error instead of wandering around my file tree wondering what the problem is.